### PR TITLE
Fix `spawn_cmd_background` for windows.

### DIFF
--- a/src/infra/browser.rs
+++ b/src/infra/browser.rs
@@ -220,7 +220,11 @@ impl Browser {
     pub(crate) fn quit(self) -> anyhow::Result<()> {
         with_async_runtime(async {
             self.webdriver.quit().await?;
-            run_silent("kill $(pidof geckodriver)").ok();
+            if cfg!(target_os = "windows") {
+                run_silent("for /f tokens^=2 %a in ('tasklist ^| findstr geckodriver') do @taskkill /PID %a /F").ok();
+            } else {
+                run_silent("kill $(pidof geckodriver)").ok();
+            }
             Ok(())
         })
     }

--- a/src/infra/subprocess.rs
+++ b/src/infra/subprocess.rs
@@ -22,7 +22,7 @@ fn spawn_cmd(cmd: &str) -> Command {
 pub(crate) fn spawn_cmd_background(cmd: &str) -> Command {
     if cfg!(target_os = "windows") {
         let mut command = Command::new("cmd");
-        let cmd = format!("START /B \"\" {}", cmd);
+        let cmd = format!("START /B {}", cmd);
         command.arg("/C").arg(&cmd);
         command
     } else {


### PR DESCRIPTION
`spawn_cmd_background`가 cmd를 통해 명령을 실행하려고 할 때 아래와 같은 문제가 발생함을 확인했습니다.
![image](https://github.com/Bubbler-4/gaboja/assets/51486948/3ea91322-55f8-438f-ae85-f4bf1be058dc)

cmd를 정의하는 부분이 문제가 되는 거 같은데,
```rust
let cmd = format!("START /B \"\" {}", cmd);
```
위 코드에서 `\"`가 `"`로 변환되어야 하지만 어째선지 역슬래시가 cmd에 그대로 들어가는 거 같습니다.

![image](https://github.com/Bubbler-4/gaboja/assets/51486948/92085a98-af7e-4c5e-b776-2ff192befae6)
`start /B \"\" geckodriver`를 cmd에 입력했을 때 동일한 오류 메시지 창을 확인할 수 있었습니다.

백그라운드 실행과 관련해서 `""`가 있는 거 같은데 `""`없이 `/B`만 있어도 백그라운드에서 동작하게 할 수 있는 것 같습니다.